### PR TITLE
Update UIActionViewController popover for iOS8 on iPad.

### DIFF
--- a/EBPhotoPagesController/EBPhotoPagesController.h
+++ b/EBPhotoPagesController/EBPhotoPagesController.h
@@ -100,7 +100,7 @@
 - (void)deletePhotoAtIndex:(NSInteger)index;
 - (void)deleteTagPopover:(EBTagPopover *)tagPopover inPhotoAtIndex:(NSInteger)index;
 
-- (void)presentActivitiesForPhotoViewController:(EBPhotoViewController *)photoViewController;
+- (void)presentActivitiesForPhotoViewController:(EBPhotoViewController *)photoViewController fromBarButtonItem:(UIBarButtonItem *)barButtonItem;
 - (void)cancelCurrentTagging;
 
 - (void)startCommenting;

--- a/EBPhotoPagesController/EBPhotoPagesController.m
+++ b/EBPhotoPagesController/EBPhotoPagesController.m
@@ -1266,7 +1266,7 @@ static NSString *kActionSheetIndexKey= @"actionSheetTargetIndex";
 }
 
 
-- (void)presentActivitiesForPhotoViewController:(EBPhotoViewController *)photoViewController
+- (void)presentActivitiesForPhotoViewController:(EBPhotoViewController *)photoViewController fromBarButtonItem:(UIBarButtonItem *)barButtonItem
 {
     NSAssert([photoViewController isKindOfClass:[EBPhotoViewController class]], @"Expected EBPhotoViewController kind of class.");
     
@@ -1300,6 +1300,10 @@ static NSString *kActionSheetIndexKey= @"actionSheetTargetIndex";
         [self setLowerBarAlpha:1.0];
     }];
     
+    if ([activityViewController respondsToSelector:@selector(popoverPresentationController)]) {
+        activityViewController.popoverPresentationController.barButtonItem = barButtonItem;
+    }
+
     [self presentViewController:activityViewController
                              animated:YES
                            completion:nil];

--- a/EBPhotoPagesController/EBPhotoPagesState.m
+++ b/EBPhotoPagesController/EBPhotoPagesState.m
@@ -195,10 +195,13 @@
 
 - (void)photoPagesController:(EBPhotoPagesController *)controller didSelectActivityButton:(id)sender
 {
-    EBPhotoViewController *photoViewController = [controller currentPhotoViewController];    
-    [controller presentActivitiesForPhotoViewController:photoViewController];
+    EBPhotoViewController *photoViewController = [controller currentPhotoViewController];
+    id senderItem = nil;
+    if ([sender isKindOfClass:[UIBarButtonItem class]]) {
+        senderItem = sender;
+    }
+    [controller presentActivitiesForPhotoViewController:photoViewController fromBarButtonItem:senderItem];
 }
-
 
 - (void)photoPagesController:(EBPhotoPagesController *)controller
    didSelectToggleTagsButton:(id)sender


### PR DESCRIPTION
The "share" UIActionViewController was crashing on iOS8 on the iPad due to new requirements that a "popoverPresentationController" item be set for the UIActionViewController to display "from". This update uses the share button as that frame of reference.
