### PR TITLE
Toolbars alpha configurable in factory 

### DIFF
--- a/EBPhotoPagesController/EBPhotoPagesController.m
+++ b/EBPhotoPagesController/EBPhotoPagesController.m
@@ -1295,7 +1295,13 @@ static NSString *kActionSheetIndexKey= @"actionSheetTargetIndex";
     }
     
     
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
     [activityViewController setCompletionHandler:^(NSString *activityType, BOOL completed){
+            
+#else
+    [activityViewController setCompletionWithItemsHandler:
+         ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
+#endif
         [self setUpperBarAlpha:[self.photoPagesFactory upperToolbarAlphaForPhotoPagesController:self]];
         [self setLowerBarAlpha:[self.photoPagesFactory lowerToolbarAlphaForPhotoPagesController:self]];
     }];

--- a/EBPhotoPagesController/EBPhotoPagesController.m
+++ b/EBPhotoPagesController/EBPhotoPagesController.m
@@ -739,9 +739,9 @@ static NSString *kActionSheetIndexKey= @"actionSheetTargetIndex";
 {
     CGFloat alpha = hidden ? 0.0 : 1.0;
     
-    [self setUpperBarAlpha:alpha];
+    [self setUpperBarAlpha:hidden ? 0.0 : [self.photoPagesFactory upperToolbarAlphaForPhotoPagesController:self]];
+    [self setLowerBarAlpha:hidden ? 0.0 : [self.photoPagesFactory lowerToolbarAlphaForPhotoPagesController:self]];
     [self setCaptionAlpha:alpha];
-    [self setLowerBarAlpha:alpha];
     [self setPhotoDimLevel:0.0];
     [self setUpperGradientAlpha:alpha];
     [self setLowerGradientAlpha:alpha];
@@ -1296,8 +1296,8 @@ static NSString *kActionSheetIndexKey= @"actionSheetTargetIndex";
     
     
     [activityViewController setCompletionHandler:^(NSString *activityType, BOOL completed){
-        [self setUpperBarAlpha:1.0];
-        [self setLowerBarAlpha:1.0];
+        [self setUpperBarAlpha:[self.photoPagesFactory upperToolbarAlphaForPhotoPagesController:self]];
+        [self setLowerBarAlpha:[self.photoPagesFactory lowerToolbarAlphaForPhotoPagesController:self]];
     }];
     
     if ([activityViewController respondsToSelector:@selector(popoverPresentationController)]) {
@@ -1431,8 +1431,8 @@ static NSString *kActionSheetIndexKey= @"actionSheetTargetIndex";
     
     [self setActionSheetTargetInfo:nil];
     
-    [self setUpperBarAlpha:1.0];
-    [self setLowerBarAlpha:1.0];
+    [self setUpperBarAlpha:[self.photoPagesFactory upperToolbarAlphaForPhotoPagesController:self]];
+    [self setLowerBarAlpha:[self.photoPagesFactory lowerToolbarAlphaForPhotoPagesController:self]];
 }
 
 - (void)performActionOnPhotoAtIndex:(NSInteger)index forButtonTitle:(NSString *)buttonTitle

--- a/EBPhotoPagesController/EBPhotoPagesFactory.h
+++ b/EBPhotoPagesController/EBPhotoPagesFactory.h
@@ -104,6 +104,8 @@
                                                    inState:(EBPhotoPagesState *)state;
 - (UIImage *)lowerToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller
                                                    inState:(EBPhotoPagesState *)state;
+- (CGFloat)upperToolbarAlphaForPhotoPagesController:(EBPhotoPagesController *)controller;
+- (CGFloat)lowerToolbarAlphaForPhotoPagesController:(EBPhotoPagesController *)controller;
 
 - (UIImage *)defaultUpperToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller;
 - (UIImage *)defaultLowerToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller;

--- a/EBPhotoPagesController/EBPhotoPagesFactory.m
+++ b/EBPhotoPagesController/EBPhotoPagesFactory.m
@@ -59,6 +59,7 @@
     [upperToolbar setBackgroundImage:toolbarBackground
                   forToolbarPosition:UIToolbarPositionAny
                           barMetrics:UIBarMetricsDefault];
+    [upperToolbar setAlpha:[self upperToolbarAlphaForPhotoPagesController:nil]];
     return upperToolbar;
 }
 
@@ -82,7 +83,7 @@
     [lowerToolbar setBackgroundImage:toolbarBackground
                   forToolbarPosition:UIToolbarPositionAny
                           barMetrics:UIBarMetricsDefault];
-    
+    [lowerToolbar setAlpha:[self lowerToolbarAlphaForPhotoPagesController:nil]];
     return lowerToolbar;
 }
 
@@ -90,7 +91,7 @@
 - (UIImage *)upperToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller
                                                    inState:(EBPhotoPagesState *)state
 {
-    return [self defaultLowerToolbarBackgroundForPhotoPagesController:controller];
+    return [self defaultUpperToolbarBackgroundForPhotoPagesController:controller];
 }
 - (UIImage *)lowerToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller
                                                    inState:(EBPhotoPagesState *)state
@@ -98,6 +99,15 @@
     return [self defaultLowerToolbarBackgroundForPhotoPagesController:controller];
 }
 
+- (CGFloat)upperToolbarAlphaForPhotoPagesController:(EBPhotoPagesController *)controller
+{
+    return [self defaultToolbarAlphaForPhotoPagesController:controller];
+}
+
+- (CGFloat)lowerToolbarAlphaForPhotoPagesController:(EBPhotoPagesController *)controller
+{
+    return [self defaultToolbarAlphaForPhotoPagesController:controller];
+}
 
 
 - (UIImage *)defaultUpperToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller
@@ -108,6 +118,11 @@
 - (UIImage *)defaultLowerToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller
 {
     return [self defaulToolbarBackgroundForPhotoPagesController:controller];
+}
+
+- (CGFloat)defaultToolbarAlphaForPhotoPagesController:(EBPhotoPagesController *)controller
+{
+    return 1.0f;
 }
 
 - (UIImage *)defaulToolbarBackgroundForPhotoPagesController:(EBPhotoPagesController *)controller


### PR DESCRIPTION
I've noticed that you can't really change the alpha for toolbars - there is one off method but every time you click on activity or share button the alpha gets restored back to 1.0 value ignoring whatever was the last alpha set. I've added methods to factory which can override the default alpha for toolbars.
